### PR TITLE
sdk fork version

### DIFF
--- a/eved/cmd/root.go
+++ b/eved/cmd/root.go
@@ -195,7 +195,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 	rootCmd.AddCommand(
 		genutilcli.InitCmd(app.ModuleBasics, app.DefaultNodeHome),
 		genutilcli.CollectGenTxsCmd(banktypes.GenesisBalancesIterator{}, app.DefaultNodeHome),
-		genutilcli.MigrateGenesisCmd(),
+//		genutilcli.MigrateGenesisCmd(),
 		genutilcli.GenTxCmd(app.ModuleBasics, encodingConfig.TxConfig, banktypes.GenesisBalancesIterator{}, app.DefaultNodeHome),
 		genutilcli.ValidateGenesisCmd(app.ModuleBasics),
 		AddGenesisAccountCmd(app.DefaultNodeHome),

--- a/go.mod
+++ b/go.mod
@@ -21,9 +21,7 @@ require (
 
 )
 
-
 require (
-	github.com/rogpeppe/go-internal v1.8.1 // indirect
 	cloud.google.com/go v0.102.0 // indirect
 	cloud.google.com/go/compute v1.7.0 // indirect
 	cloud.google.com/go/iam v0.3.0 // indirect
@@ -133,6 +131,7 @@ require (
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 // indirect
 	github.com/regen-network/cosmos-proto v0.3.1 // indirect
+	github.com/rogpeppe/go-internal v1.8.1 // indirect
 	github.com/rs/cors v1.8.2 // indirect
 	github.com/rs/zerolog v1.27.0 // indirect
 	github.com/sasha-s/go-deadlock v0.2.1-0.20190427202633-1595213edefa // indirect
@@ -172,6 +171,8 @@ require (
 replace (
 	// https://github.com/CosmWasm/wasmd/pull/938
 	github.com/CosmWasm/wasmd => github.com/notional-labs/wasmd v0.25.1-0.20220911011224-44c1674f13fc
+	// cosmos-sdk -  https://github.com/eve-network/cosmos-sdk
+	github.com/cosmos/cosmos-sdk => github.com/eve-network/cosmos-sdk v0.46.2-0.20220914041419-9d609acabbca
 	// Fix upstream GHSA-h395-qcrw-5vmq vulnerability.
 	// TODO Remove it: https://github.com/cosmos/cosmos-sdk/issues/10409
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -172,7 +172,7 @@ replace (
 	// https://github.com/CosmWasm/wasmd/pull/938
 	github.com/CosmWasm/wasmd => github.com/notional-labs/wasmd v0.25.1-0.20220911011224-44c1674f13fc
 	// cosmos-sdk -  https://github.com/eve-network/cosmos-sdk
-	github.com/cosmos/cosmos-sdk => github.com/eve-network/cosmos-sdk v0.46.2-0.20220914041419-9d609acabbca
+	github.com/cosmos/cosmos-sdk => github.com/eve-network/cosmos-sdk v0.46.2-0.20220914044906-6510a48facc2
 	// Fix upstream GHSA-h395-qcrw-5vmq vulnerability.
 	// TODO Remove it: https://github.com/cosmos/cosmos-sdk/issues/10409
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -257,8 +257,6 @@ github.com/cosmos/btcutil v1.0.4 h1:n7C2ngKXo7UC9gNyMNLbzqz7Asuf+7Qv4gnX/rOdQ44=
 github.com/cosmos/btcutil v1.0.4/go.mod h1:Ffqc8Hn6TJUdDgHBwIZLtrLQC1KdJ9jGJl/TvgUaxbU=
 github.com/cosmos/cosmos-proto v1.0.0-alpha7 h1:yqYUOHF2jopwZh4dVQp3xgqwftE5/2hkrwIV6vkUbO0=
 github.com/cosmos/cosmos-proto v1.0.0-alpha7/go.mod h1:dosO4pSAbJF8zWCzCoTWP7nNsjcvSUBQmniFxDg5daw=
-github.com/cosmos/cosmos-sdk v0.46.1 h1:7vUZXMyrmEb4xtBYpz1TobtrcnpgiZTi+tVjc0XWB4o=
-github.com/cosmos/cosmos-sdk v0.46.1/go.mod h1:2+o8Qw8qnE02V+lQVZDJFQ8tri/hsiA5GmWaPERqVa0=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
@@ -344,6 +342,8 @@ github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
 github.com/ethereum/go-ethereum v1.10.17/go.mod h1:Lt5WzjM07XlXc95YzrhosmR4J9Ahd6X2wyEV2SvGhk0=
+github.com/eve-network/cosmos-sdk v0.46.2-0.20220914041419-9d609acabbca h1:0wQHZpKrKUfJ7NK20SS0sqpzZUlzWP2mC88w7SHz7qI=
+github.com/eve-network/cosmos-sdk v0.46.2-0.20220914041419-9d609acabbca/go.mod h1:ZEfX/ItBmtZVTrE4cJfVtExxyv3wa6BSFd2f2jO7AaM=
 github.com/facebookgo/ensure v0.0.0-20200202191622-63f1cf65ac4c h1:8ISkoahWXwZR41ois5lSJBSVw4D0OV19Ht/JSTzvSv0=
 github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 h1:JWuenKqqX8nojtoVVWjGfOF9635RETekkoH6Cc9SX0A=
 github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4 h1:7HZCaLC5+BZpmbhCOZJ293Lz68O7PYrF2EzeiFMwCLk=

--- a/go.sum
+++ b/go.sum
@@ -342,8 +342,8 @@ github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
 github.com/ethereum/go-ethereum v1.10.17/go.mod h1:Lt5WzjM07XlXc95YzrhosmR4J9Ahd6X2wyEV2SvGhk0=
-github.com/eve-network/cosmos-sdk v0.46.2-0.20220914041419-9d609acabbca h1:0wQHZpKrKUfJ7NK20SS0sqpzZUlzWP2mC88w7SHz7qI=
-github.com/eve-network/cosmos-sdk v0.46.2-0.20220914041419-9d609acabbca/go.mod h1:ZEfX/ItBmtZVTrE4cJfVtExxyv3wa6BSFd2f2jO7AaM=
+github.com/eve-network/cosmos-sdk v0.46.2-0.20220914044906-6510a48facc2 h1:lZVOb/hX+xwVoJiBdJQC3FvkQOPkVIHnR+E+PkuVKXI=
+github.com/eve-network/cosmos-sdk v0.46.2-0.20220914044906-6510a48facc2/go.mod h1:ZEfX/ItBmtZVTrE4cJfVtExxyv3wa6BSFd2f2jO7AaM=
 github.com/facebookgo/ensure v0.0.0-20200202191622-63f1cf65ac4c h1:8ISkoahWXwZR41ois5lSJBSVw4D0OV19Ht/JSTzvSv0=
 github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 h1:JWuenKqqX8nojtoVVWjGfOF9635RETekkoH6Cc9SX0A=
 github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4 h1:7HZCaLC5+BZpmbhCOZJ293Lz68O7PYrF2EzeiFMwCLk=


### PR DESCRIPTION
This branch is one of the two competing pull requests that @vuong177 and I made to figure out the best way to add the liquidity module.  

In my approach, I forked the cosmos-sdk, pulled in the liquidity module, and then rebuilt protos and the like, then replaced the cosmos-sdk in eve's go.mod file.  In order to complete my approach, we would need to remove beginblock and endblock elements from the cosmos-sdk so that we can have variable block timing.

We would need to review my fork of the cosmos-sdk to ensure that it passes 100% of tests, for example, in simapp, there's a minimum self delegation issue (I think)