### PR TITLE
refactor: bump ics v4->v5 and enable ics

### DIFF
--- a/cmd/consumer.go
+++ b/cmd/consumer.go
@@ -9,7 +9,6 @@ import (
 	pvm "github.com/cometbft/cometbft/privval"
 	tmtypes "github.com/cometbft/cometbft/types"
 	ccvconsumertypes "github.com/cosmos/interchain-security/v5/x/ccv/consumer/types"
-	ccvtypes "github.com/cosmos/interchain-security/v5/x/ccv/types"
 	"github.com/eve-network/eve/testutil"
 	"github.com/spf13/cobra"
 
@@ -152,9 +151,9 @@ type GenesisData struct {
 	GenesisFile         string
 	GenDoc              *genutiltypes.AppGenesis
 	AppState            map[string]json.RawMessage
-	ConsumerModuleState *ccvtypes.ConsumerGenesisState
+	ConsumerModuleState *ccvconsumertypes.GenesisState
 }
 
-func NewGenesisData(genesisFile string, genDoc *genutiltypes.AppGenesis, appState map[string]json.RawMessage, consumerModuleState *ccvtypes.ConsumerGenesisState) *GenesisData {
+func NewGenesisData(genesisFile string, genDoc *genutiltypes.AppGenesis, appState map[string]json.RawMessage, consumerModuleState *ccvconsumertypes.GenesisState) *GenesisData {
 	return &GenesisData{GenesisFile: genesisFile, GenDoc: genDoc, AppState: appState, ConsumerModuleState: consumerModuleState}
 }

--- a/cmd/consumer.go
+++ b/cmd/consumer.go
@@ -8,8 +8,8 @@ import (
 	types1 "github.com/cometbft/cometbft/abci/types"
 	pvm "github.com/cometbft/cometbft/privval"
 	tmtypes "github.com/cometbft/cometbft/types"
-	ccvconsumertypes "github.com/cosmos/interchain-security/v4/x/ccv/consumer/types"
-	ccvtypes "github.com/cosmos/interchain-security/v4/x/ccv/types"
+	ccvconsumertypes "github.com/cosmos/interchain-security/v5/x/ccv/consumer/types"
+	ccvtypes "github.com/cosmos/interchain-security/v5/x/ccv/types"
 	"github.com/eve-network/eve/testutil"
 	"github.com/spf13/cobra"
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/cosmos/gogoproto v1.4.11
 	github.com/cosmos/iavl v1.0.1 // indirect
 	github.com/cosmos/ics23/go v0.10.0 // indirect
-	github.com/cosmos/interchain-security/v4 v4.0.0-20240308155501-e731e82d77f1
+	github.com/cosmos/interchain-security/v5 v5.0.0-alpha1
 	github.com/dvsekhvalnov/jose2go v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -376,8 +376,8 @@ github.com/cosmos/ibc-go/v8 v8.1.0 h1:pf1106wl0Cf+p1+FjXzV6odlS9DnqVunPVWCH1Uz+l
 github.com/cosmos/ibc-go/v8 v8.1.0/go.mod h1:o1ipS95xpdjqNcB8Drq0eI3Sn4FRLigjll42ec1ECuU=
 github.com/cosmos/ics23/go v0.10.0 h1:iXqLLgp2Lp+EdpIuwXTYIQU+AiHj9mOC2X9ab++bZDM=
 github.com/cosmos/ics23/go v0.10.0/go.mod h1:ZfJSmng/TBNTBkFemHHHj5YY7VAU/MBU980F4VU1NG0=
-github.com/cosmos/interchain-security/v4 v4.0.0-20240308155501-e731e82d77f1 h1:BgDLjWTRd7JiVcd86zmfx8vMVgcfKuYmT98ZVDRG0vY=
-github.com/cosmos/interchain-security/v4 v4.0.0-20240308155501-e731e82d77f1/go.mod h1:aU71ExUrytxHtdPqteT4ONrooTeDwUGJHRTJd8L3SWQ=
+github.com/cosmos/interchain-security/v5 v5.0.0-alpha1 h1:hDFOAw5mSZzlaiEM7vGPImObaLRbbGiR+vIXfkzW/0Q=
+github.com/cosmos/interchain-security/v5 v5.0.0-alpha1/go.mod h1:c4oYjNwdfPKAhxzkwzTkkWROXKeUNPvc4VJHyNWrRU8=
 github.com/cosmos/keyring v1.2.0 h1:8C1lBP9xhImmIabyXW4c3vFjjLiBdGCmfLUfeZlV1Yo=
 github.com/cosmos/keyring v1.2.0/go.mod h1:fc+wB5KTk9wQ9sDx0kFXB3A0MaeGHM9AwRStKOQ5vOA=
 github.com/cosmos/ledger-cosmos-go v0.13.3 h1:7ehuBGuyIytsXbd4MP43mLeoN2LTOEnk5nvue4rK+yM=

--- a/scripts/start_local_node.sh
+++ b/scripts/start_local_node.sh
@@ -9,9 +9,9 @@ DENOM=ueve
 EVE_ADMIN_MNEMONIC="gorilla bind ghost erode play crack ancient flight mountain floor rent flip lens split today winter oil arctic recycle lab reform habit keep cactus"
 EVE_VAL_MNEMONIC="jeans agree enter oak sure amateur ride ceiling museum bunker weekend fruit give truth blush lucky ball chunk regret mirror leader pudding mirror web"
 
-MAX_DEPOSIT_PERIOD="86401s"
-VOTING_PERIOD="86401s"
-UNBONDING_TIME="86401s"
+MAX_DEPOSIT_PERIOD="20s"
+VOTING_PERIOD="20s"
+UNBONDING_TIME="20s"
 
 config_toml="${EVE_HOME}/config/config.toml"
 client_toml="${EVE_HOME}/config/client.toml"
@@ -38,25 +38,10 @@ jq '.app_state.gov.params.voting_period = $newVal' --arg newVal "$VOTING_PERIOD"
 rm -rf ~/.eve-loca1
 cp -r ${EVE_HOME} ~/.eve-loca1
 
-#$EVED add-consumer-section 1
-#jq '.app_state.ccvconsumer.params.unbonding_period = $newVal' --arg newVal "$UNBONDING_TIME" $genesis_json > json.tmp && mv json.tmp $genesis_json
+$EVED add-consumer-section 1
+jq '.app_state.ccvconsumer.params.unbonding_period = $newVal' --arg newVal "$UNBONDING_TIME" $genesis_json > json.tmp && mv json.tmp $genesis_json
 
 rm -rf ~/.eve-loca1
-
-echo "$EVE_VAL_MNEMONIC" | $EVED keys add val --recover --keyring-backend=test
-$EVED genesis add-genesis-account val 200000000000${DENOM} --keyring-backend=test
-
-echo "$EVE_ADMIN_MNEMONIC" | $EVED keys add admin --recover --keyring-backend=test
-$EVED genesis add-genesis-account admin 200000000000${DENOM} --keyring-backend=test
-
-COMMISSION_RATE=0.01
-COMMISSION_MAX_RATE=0.02
-
-# Sign genesis transaction
-$EVED genesis gentx val "1000000${DENOM}" --commission-rate=$COMMISSION_RATE --commission-max-rate=$COMMISSION_MAX_RATE --keyring-backend=test --chain-id $CHAIN_ID --home $EVE_HOME
-
-# Collect genesis tx
-$EVED genesis collect-gentxs --home $EVE_HOME
 
 # Start the daemon in the background
 $EVED start

--- a/testutil/consumer.go
+++ b/testutil/consumer.go
@@ -6,8 +6,8 @@ import (
 	ibctypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types" //nolint:staticcheck
 	"github.com/cosmos/ibc-go/v8/modules/core/23-commitment/types"
 	ibctmtypes "github.com/cosmos/ibc-go/v8/modules/light-clients/07-tendermint"
-	ccvprovidertypes "github.com/cosmos/interchain-security/v4/x/ccv/provider/types"
-	ccvtypes "github.com/cosmos/interchain-security/v4/x/ccv/types"
+	ccvprovidertypes "github.com/cosmos/interchain-security/v5/x/ccv/provider/types"
+	ccvtypes "github.com/cosmos/interchain-security/v5/x/ccv/types"
 )
 
 func CreateMinimalConsumerTestGenesis() *ccvtypes.ConsumerGenesisState {

--- a/testutil/consumer.go
+++ b/testutil/consumer.go
@@ -3,21 +3,22 @@ package testutil
 import (
 	"time"
 
-	ibctypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types" //nolint:staticcheck
-	"github.com/cosmos/ibc-go/v8/modules/core/23-commitment/types"
+	ibcclienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types" //nolint:staticcheck
+	ibccommitmenttypes "github.com/cosmos/ibc-go/v8/modules/core/23-commitment/types"
 	ibctmtypes "github.com/cosmos/ibc-go/v8/modules/light-clients/07-tendermint"
+	ccvconsumertypes "github.com/cosmos/interchain-security/v5/x/ccv/consumer/types"
 	ccvprovidertypes "github.com/cosmos/interchain-security/v5/x/ccv/provider/types"
-	ccvtypes "github.com/cosmos/interchain-security/v5/x/ccv/types"
+	"github.com/cosmos/interchain-security/v5/x/ccv/types"
 )
 
-func CreateMinimalConsumerTestGenesis() *ccvtypes.ConsumerGenesisState {
-	genesisState := ccvtypes.DefaultConsumerGenesisState()
+func CreateMinimalConsumerTestGenesis() *ccvconsumertypes.GenesisState {
+	genesisState := ccvconsumertypes.DefaultGenesisState()
 	genesisState.Params.Enabled = true
 	genesisState.NewChain = true
 	genesisState.Provider.ClientState = ccvprovidertypes.DefaultParams().TemplateClient
 	genesisState.Provider.ClientState.ChainId = "eve"
-	genesisState.Provider.ClientState.LatestHeight = ibctypes.Height{RevisionNumber: 0, RevisionHeight: 1}
-	trustPeriod, err := ccvtypes.CalculateTrustPeriod(genesisState.Params.UnbondingPeriod, ccvprovidertypes.DefaultTrustingPeriodFraction)
+	genesisState.Provider.ClientState.LatestHeight = ibcclienttypes.Height{RevisionNumber: 0, RevisionHeight: 1}
+	trustPeriod, err := types.CalculateTrustPeriod(genesisState.Params.UnbondingPeriod, ccvprovidertypes.DefaultTrustingPeriodFraction)
 	if err != nil {
 		panic("provider client trusting period error")
 	}
@@ -26,7 +27,7 @@ func CreateMinimalConsumerTestGenesis() *ccvtypes.ConsumerGenesisState {
 	genesisState.Provider.ClientState.MaxClockDrift = ccvprovidertypes.DefaultMaxClockDrift
 	genesisState.Provider.ConsensusState = &ibctmtypes.ConsensusState{
 		Timestamp: time.Now().UTC(),
-		Root:      types.MerkleRoot{Hash: []byte("dummy")},
+		Root:      ibccommitmenttypes.MerkleRoot{Hash: []byte("dummy")},
 	}
 
 	return genesisState


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated interchain security modules to version 5 for enhanced functionality and compatibility.
- **Refactor**
	- Adjusted usage from `StakingKeeper` to `ConsumerKeeper` to align with updated module requirements.
- **Chores**
	- Modified local node start-up script to significantly reduce deposit, voting, and unbonding times for improved testing efficiency.
	- Cleaned up script files by removing outdated commented sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->