### PR TITLE
Using ibc-go release version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,22 @@
 # eve
 
-Eve is a governance minimized CosmWasm blockchain intended to push forward the state of the art in Cosmos.  
+Eve is a governance minimized CosmWasm blockchain intended to push forward the state of the art in Cosmos.
 
-Contract uploads are not permissioned in any way, and governance thresholds have been adjusted to ensure that contract authors are not disturbed in their work.   This chain emphasizes decentralization, interchain capability and governance minimization.  
+Contract uploads are not permissioned in any way, and governance thresholds have been adjusted to ensure that contract authors are not disturbed in their work.   This chain emphasizes decentralization, interchain capability and governance minimization.
 
-Eve won't compete with your contracts, and views herself as a beautiful, fertile platform for authors to bring their visions to life.  
+Eve won't compete with your contracts, and views herself as a beautiful, fertile platform for authors to bring their visions to life.
 
 ## Software at launch
 
-* cosmos-sdk v0.50.x 
-* cometbft v0.38.x 
+* cosmos-sdk v0.50.x
+* cometbft v0.38.x
 * CosmWasm v0.51.x
 * WasmVM v2.0.x
-* IBC-go v8.1.x
+* ibc-go v8.3.x
 * Token Factory
 * IBC Hooks
 
 This also means that Eve, as a loving mother and repeatable template, is committed to ensuring that the modules and middlewares above are kept up to date rigorously, with "up to date" being defined as supporting the latest release of cosmos-sdk, **regardless of the decisions of other teams**.  Eve is very confident in the current cosmos-sdk and ibc-go maintenance teams and smiles warmly at them.
-
 
 ## Planned software
 
@@ -39,7 +38,7 @@ Likely stuff built and tested here feeds into White Whale, Composable, Cyber, Sp
 
 Contributors == team.
 
-Quicksilver and affiliated teams plan to use eve to put the newest SDK, IBC and WASMD into produciton quickly.  If you have ideas for eve, please feel free to fork and make a PR.  
+Quicksilver and affiliated teams plan to use eve to put the newest SDK, IBC and WASMD into produciton quickly.  If you have ideas for eve, please feel free to fork and make a PR.
 
 If you want to write an upgrade for Eve, it can be shipped from any repository, and you can just reference the url and commit hash.
 
@@ -47,12 +46,9 @@ If you want to write an upgrade for Eve, it can be shipped from any repository, 
 
 Eve will remain as simple as possible, while using the latest cosmos ecosystem libraries.  Eve won't use her community pool to compete with your contracts, becasue eve does not have a community pool.
 
-
 ## No Promises
 
-Eve doesn't make promises and may not be exactly as described because she's an exploration of ideas first and foremost.  This includes the airdrop.  
-
-
+Eve doesn't make promises and may not be exactly as described because she's an exploration of ideas first and foremost.  This includes the airdrop.
 
 ## Economic Information
 
@@ -60,7 +56,7 @@ Eve thinks that beauty comes from simplicity, and economic design follows this.
 
 ## Imperative
 
-From eve will flow new designs and techniques that increase development velocity and ease of use across Cosmos.  
+From eve will flow new designs and techniques that increase development velocity and ease of use across Cosmos.
 
 ## Contributing
 

--- a/app/app.go
+++ b/app/app.go
@@ -703,7 +703,6 @@ func NewEveApp(
 		app.AccountKeeper,
 		scopedICAHostKeeper,
 		app.MsgServiceRouter(),
-		app.GRPCQueryRouter(),
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 	)
 	app.ICAControllerKeeper = icacontrollerkeeper.NewKeeper(
@@ -745,9 +744,6 @@ func NewEveApp(
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 		wasmOpts...,
 	)
-	clientRouter := app.IBCKeeper.ClientKeeper.GetRouter()
-	tmLightClientModule := ibctm.NewLightClientModule(appCodec, authtypes.NewModuleAddress(govtypes.ModuleName).String())
-	clientRouter.AddRoute(ibctm.ModuleName, &tmLightClientModule)
 
 	// NOTE: we may consider parsing `appOpts` inside module constructors. For the moment
 	// we prefer to be more strict in what arguments the modules expect.
@@ -787,7 +783,7 @@ func NewEveApp(
 		transfer.NewAppModule(app.TransferKeeper),
 		ibcfee.NewAppModule(app.IBCFeeKeeper),
 		ica.NewAppModule(&app.ICAControllerKeeper, &app.ICAHostKeeper),
-		ibctm.NewAppModule(tmLightClientModule),
+		ibctm.NewAppModule(),
 		ibchooks.NewAppModule(app.AccountKeeper),
 		alliancemodule.NewAppModule(appCodec, app.AllianceKeeper, app.StakingKeeper, app.AccountKeeper, app.BankKeeper, app.interfaceRegistry, app.GetSubspace(alliancemoduletypes.ModuleName)),
 

--- a/go.mod
+++ b/go.mod
@@ -50,8 +50,8 @@ require (
 	github.com/cosmos/cosmos-db v1.0.2
 	github.com/cosmos/ibc-apps/modules/ibc-hooks/v8 v8.0.0-20240530162148-4827cf263165
 	github.com/cosmos/ibc-go/modules/capability v1.0.0
-	github.com/cosmos/ibc-go/modules/light-clients/08-wasm v0.0.0-20240522213438-180501e6389d
-	github.com/cosmos/ibc-go/v8 v8.2.1
+	github.com/cosmos/ibc-go/modules/light-clients/08-wasm v0.2.1-0.20240523101951-4b45d1822fb6
+	github.com/cosmos/ibc-go/v8 v8.3.2
 	github.com/osmosis-labs/tokenfactory v0.0.0-20240310155926-981fbeb0fe42
 	github.com/terra-money/alliance v0.4.3
 )
@@ -222,9 +222,6 @@ replace (
 	// core v0.12 was tagged wrong (sdk51)
 	cosmossdk.io/core => cosmossdk.io/core v0.11.0
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
-	// github.com/cosmos/ibc-go/modules/light-clients/08-wasm => github.com/notional-labs/ibc-go/modules/light-clients/08-wasm v0.0.0-20240314043527-f53cabfd50c0
-
-	github.com/cosmos/ibc-go/v8 => github.com/cosmos/ibc-go/v8 v8.0.0-20240403130056-50d2a087d555
 
 	// dgrijalva/jwt-go is deprecated and doesn't receive security updates.
 	// See: https://github.com/cosmos/cosmos-sdk/issues/13134

--- a/go.sum
+++ b/go.sum
@@ -788,10 +788,10 @@ github.com/cosmos/ibc-apps/modules/ibc-hooks/v8 v8.0.0-20240530162148-4827cf2631
 github.com/cosmos/ibc-apps/modules/ibc-hooks/v8 v8.0.0-20240530162148-4827cf263165/go.mod h1:9+Z14xz3Y+5uEn5i1CvLcDN1aTthEhYUdI7pphySkY8=
 github.com/cosmos/ibc-go/modules/capability v1.0.0 h1:r/l++byFtn7jHYa09zlAdSeevo8ci1mVZNO9+V0xsLE=
 github.com/cosmos/ibc-go/modules/capability v1.0.0/go.mod h1:D81ZxzjZAe0ZO5ambnvn1qedsFQ8lOwtqicG6liLBco=
-github.com/cosmos/ibc-go/modules/light-clients/08-wasm v0.0.0-20240522213438-180501e6389d h1:NnfAPgj99IW5Hu4VtipDF/hW+/Eba4Cvs0GQ3k2IiV8=
-github.com/cosmos/ibc-go/modules/light-clients/08-wasm v0.0.0-20240522213438-180501e6389d/go.mod h1:KIBqXSJFaEo2137FEKc5cGVModykbzJI28P8AdwmjKI=
-github.com/cosmos/ibc-go/v8 v8.0.0-20240403130056-50d2a087d555 h1:YnYWXXk2j0nWeFhw+ByvJIWOHAgQy7O6SmfNdh6uz/U=
-github.com/cosmos/ibc-go/v8 v8.0.0-20240403130056-50d2a087d555/go.mod h1:e8082q1O3a5Kas3NOHqVon3IKzlQlk7UoMIAz0xV2+8=
+github.com/cosmos/ibc-go/modules/light-clients/08-wasm v0.2.1-0.20240523101951-4b45d1822fb6 h1:cq9xPsRYXr1DJG0h1rrxlE+JKZh7s5z/jSgnG2YmR18=
+github.com/cosmos/ibc-go/modules/light-clients/08-wasm v0.2.1-0.20240523101951-4b45d1822fb6/go.mod h1:ab73pB/hwAFSa98oUwtMiNF6T1NyRwo6sjLjaYrkHHI=
+github.com/cosmos/ibc-go/v8 v8.3.2 h1:8X1oHHKt2Bh9hcExWS89rntLaCKZp2EjFTUSxKlPhGI=
+github.com/cosmos/ibc-go/v8 v8.3.2/go.mod h1:WVVIsG39jGrF9Cjggjci6LzySyWGloz194sjTxiGNIE=
 github.com/cosmos/ics23/go v0.10.0 h1:iXqLLgp2Lp+EdpIuwXTYIQU+AiHj9mOC2X9ab++bZDM=
 github.com/cosmos/ics23/go v0.10.0/go.mod h1:ZfJSmng/TBNTBkFemHHHj5YY7VAU/MBU980F4VU1NG0=
 github.com/cosmos/keyring v1.2.0 h1:8C1lBP9xhImmIabyXW4c3vFjjLiBdGCmfLUfeZlV1Yo=


### PR DESCRIPTION
Closes #249.

Importing the 08-wasm module note:
[https://github.com/cosmos/ibc-go/blob/main/docs/docs/03-light-clients/04-wasm/03-integration.md#importing-the-08-wasm-module](https://github.com/cosmos/ibc-go/blob/main/docs/docs/03-light-clients/04-wasm/03-integration.md#importing-the-08-wasm-module)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated README with improved descriptions, fixed typos, clarified statements, and adjusted formatting.

- **Chores**
  - Updated dependencies to new versions in `go.mod`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->