### PR TITLE
fix: pass bank keeper to ante handler

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1100,6 +1100,7 @@ func (app *EveApp) setAnteHandler(txConfig client.TxConfig, wasmConfig wasmtypes
 			CircuitKeeper:         &app.CircuitKeeper,
 			FeeMarketKeeper:       app.FeeMarketKeeper,
 			AccountKeeper:         app.AccountKeeper,
+			BankKeeper:            app.BankKeeper,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
ante handler was throwing error that bank keeper is nil, because we were not passing it